### PR TITLE
[ Feat ] 설정페이지 구현 Modal 사용

### DIFF
--- a/src/app/@modal/default.tsx
+++ b/src/app/@modal/default.tsx
@@ -1,0 +1,5 @@
+const Default = () => {
+  return null;
+};
+
+export default Default;

--- a/src/app/@modal/user/[userId]/(.)main-setting/page.tsx
+++ b/src/app/@modal/user/[userId]/(.)main-setting/page.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Modal } from '@/shared/components/modal/modal';
+import { ModalContentMainSetting } from '@/shared/components/modalContentMainSetting/modalContentMainSetting';
+
+const page = () => {
+  return (
+    <Modal title="설정">
+      <ModalContentMainSetting
+        userSchool="userSchool"
+        userRegion="userRegion"
+      />
+    </Modal>
+  );
+};
+
+export default page;

--- a/src/app/@modal/user/[userId]/(.)region-setting/page.tsx
+++ b/src/app/@modal/user/[userId]/(.)region-setting/page.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Modal } from '@/shared/components/modal/modal';
+import ModalContentRegionSetting from '@/shared/components/modalContentRegionSetting/modalContentRegionSetting';
+
+const page = () => {
+  return (
+    <Modal title="소속지역 변경">
+      <ModalContentRegionSetting />
+    </Modal>
+  );
+};
+
+export default page;

--- a/src/app/@modal/user/[userId]/(.)school-setting/page.tsx
+++ b/src/app/@modal/user/[userId]/(.)school-setting/page.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Modal } from '@/shared/components/modal/modal';
+import { ModalContentSchoolSetting } from '@/shared/components/modalContentSchoolSetting/modalContentSchoolSetting';
+
+const page = () => {
+  return (
+    <Modal title="소속학교 변경">
+      <ModalContentSchoolSetting />
+    </Modal>
+  );
+};
+
+export default page;

--- a/src/app/about/aboutPage.css.ts
+++ b/src/app/about/aboutPage.css.ts
@@ -2,7 +2,15 @@ import { style } from '@vanilla-extract/css';
 import { globalTheme } from '@/shared/styles/globalTheme.css';
 
 export const divStyle = style({
-  width: '100%',
+  margin: '0 auto',
+  padding: '0 3.8rem',
+  width: '1180px',
+
+  '@media': {
+    '(max-width: 1180px)': {
+      width: '100%',
+    },
+  },
 });
 
 export const sectionStyle = style({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,12 +11,15 @@ export const metadata: Metadata = {
 
 export default function RootLayout({
   children,
+  modal,
 }: Readonly<{
   children: React.ReactNode;
+  modal: React.ReactNode;
 }>) {
   return (
     <html lang="ko">
       <body>
+        {modal}
         <Header />
         <main className={mainStyle}>{children}</main>
         <Footer />

--- a/src/app/user/[userId]/main-setting/page.tsx
+++ b/src/app/user/[userId]/main-setting/page.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Modal } from '@/shared/components/modal/modal';
+import { ModalContentMainSetting } from '@/shared/components/modalContentMainSetting/modalContentMainSetting';
+
+const page = () => {
+  return (
+    <Modal title="설정">
+      <ModalContentMainSetting
+        userSchool="userSchool"
+        userRegion="userRegion"
+      />
+    </Modal>
+  );
+};
+
+export default page;

--- a/src/app/user/[userId]/region-setting/page.tsx
+++ b/src/app/user/[userId]/region-setting/page.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Modal } from '@/shared/components/modal/modal';
+import ModalContentRegionSetting from '@/shared/components/modalContentRegionSetting/modalContentRegionSetting';
+
+const page = () => {
+  return (
+    <Modal title="소속지역 변경">
+      <ModalContentRegionSetting />
+    </Modal>
+  );
+};
+
+export default page;

--- a/src/app/user/[userId]/school-setting/page.tsx
+++ b/src/app/user/[userId]/school-setting/page.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Modal } from '@/shared/components/modal/modal';
+import { ModalContentSchoolSetting } from '@/shared/components/modalContentSchoolSetting/modalContentSchoolSetting';
+
+const page = () => {
+  return (
+    <Modal title="소속학교 변경">
+      <ModalContentSchoolSetting />
+    </Modal>
+  );
+};
+
+export default page;

--- a/src/shared/assets/svg/arrow_back.svg
+++ b/src/shared/assets/svg/arrow_back.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="40px" viewBox="0 0 24 24" width="40px" fill="#c1c1c1"><path d="M0 0h24v24H0z" fill="none"/><path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"/></svg>

--- a/src/shared/components/modal/modal.css.ts
+++ b/src/shared/components/modal/modal.css.ts
@@ -1,0 +1,43 @@
+import { style } from '@vanilla-extract/css';
+import { globalTheme } from '@/shared/styles/globalTheme.css';
+
+export const modalStyle = style({
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  width: '100%',
+  height: '100%',
+  backgroundColor: 'rgba(25, 25, 25, 0.4)', // #191919에 opacity 0.4 적용 grobal theme로 변경해야함
+  zIndex: 1000,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+});
+
+export const contentStyle = style({
+  backgroundColor: globalTheme.colors.white,
+
+  padding: '4.8rem',
+  borderRadius: '0.8rem',
+  width: '120rem',
+  height: '74.8rem',
+});
+
+export const divHeaderStyle = style({
+  display: 'flex',
+  alignItems: 'center',
+  marginBottom: '2.4rem',
+});
+
+export const headerStyle = style({
+  position: 'absolute',
+  left: '50%',
+  transform: 'translateX(-50%)',
+  ...globalTheme.fonts.headBold36,
+  color: globalTheme.colors.gray_19,
+});
+
+export const ArrowBackStyle = style({
+  width: '3.2rem',
+  height: '3.2rem',
+});

--- a/src/shared/components/modal/modal.tsx
+++ b/src/shared/components/modal/modal.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import ArrowBack from '@/shared/assets/svg/arrow_back.svg';
+import {
+  modalStyle,
+  contentStyle,
+  divHeaderStyle,
+  headerStyle,
+} from './modal.css';
+
+export function Modal({
+  children,
+  title = '설정',
+}: {
+  children: React.ReactNode;
+  title?: string;
+}) {
+  const router = useRouter();
+
+  const handleOutsideClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === e.currentTarget) {
+      router.back();
+    }
+  };
+
+  return (
+    <div className={modalStyle} onClick={handleOutsideClick}>
+      <div className={contentStyle}>
+        <div className={divHeaderStyle}>
+          <ArrowBack
+            onClick={() => {
+              router.back();
+            }}
+          />
+          <h1 className={headerStyle}>{title}</h1>
+        </div>
+        <div>{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/shared/components/modalContentMainSetting/modalContentMainSetting.css.ts
+++ b/src/shared/components/modalContentMainSetting/modalContentMainSetting.css.ts
@@ -1,0 +1,33 @@
+import { style } from '@vanilla-extract/css';
+import { globalTheme } from '@/shared/styles/globalTheme.css';
+
+export const headingStyle = style({
+  ...globalTheme.fonts.headBold24,
+  color: globalTheme.colors.gray_19,
+  marginTop: '4.8rem',
+  marginBottom: '1.6rem',
+  marginLeft: '4.8rem',
+});
+
+export const sectionStyle = style({
+  width: '100%',
+  height: '100%',
+  paddingLeft: 48,
+  paddingRight: 48,
+  paddingTop: 10,
+  paddingBottom: 10,
+  background: 'white',
+  borderBottom: `1px ${globalTheme.colors.gray_stroke_E2} solid`,
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  display: 'inline-flex',
+});
+
+export const paragraphStyle1 = style({
+  ...globalTheme.fonts.subheadBold20,
+  color: globalTheme.colors.gray_19,
+});
+export const paragraphStyle2 = style({
+  ...globalTheme.fonts.bodyReg16,
+  color: globalTheme.colors.gray_71,
+});

--- a/src/shared/components/modalContentMainSetting/modalContentMainSetting.tsx
+++ b/src/shared/components/modalContentMainSetting/modalContentMainSetting.tsx
@@ -1,0 +1,76 @@
+import Link from 'next/link';
+import Button from '@/shared/components/button/button';
+import {
+  headingStyle,
+  sectionStyle,
+  paragraphStyle1,
+  paragraphStyle2,
+} from './modalContentMainSetting.css';
+
+export function ModalContentMainSetting({
+  userSchool,
+  userRegion,
+}: {
+  userSchool: string | undefined;
+  userRegion: string;
+}) {
+  return (
+    <>
+      <p className={headingStyle}>정보 변경</p>
+      <div className={sectionStyle}>
+        <div>
+          <p className={paragraphStyle1}>
+            소속학교: {userSchool || '학교 없음'}
+          </p>
+          <p className={paragraphStyle2}>
+            변경 버튼을 눌러 재인증을 통해 소속학교를 변경할 수 있습니다.
+          </p>
+        </div>
+        <div>
+          <Link href="/ModalContentSchoolSetting">
+            <Button>변경하기</Button>
+          </Link>
+        </div>
+      </div>
+      <div className={sectionStyle}>
+        <div>
+          <p className={paragraphStyle1}>
+            소속지역: {userRegion || '지역 없음'}
+          </p>
+          <p className={paragraphStyle2}>
+            변경 버튼을 눌러 소속지역를 변경할 수 있습니다.
+          </p>
+        </div>
+        <div>
+          <Link href="/ModalContentRegionSetting">
+            <Button>변경하기</Button>
+          </Link>
+        </div>
+      </div>
+
+      <p className={headingStyle}>계정 정보</p>
+      <div className={sectionStyle}>
+        <div>
+          <p className={paragraphStyle1}>서비스 로그아웃</p>
+          <p className={paragraphStyle2}>
+            서비스에서 로그아웃 합니다. 메인 화면으로 이동합니다.
+          </p>
+        </div>
+        <div>
+          {/* 텍스트버튼 만들면 변경 */}
+          <button>로그아웃</button>
+        </div>
+      </div>
+      <div className={sectionStyle}>
+        <div>
+          <p className={paragraphStyle1}>서비스 탈퇴</p>
+          <p className={paragraphStyle2}>탈퇴 시 모든 정보는 삭제 됩니다.</p>
+        </div>
+        <div>
+          {/* 텍스트버튼 만들면 변경 */}
+          <button>탈퇴하기</button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/shared/components/modalContentRegionSetting/modalContentRegionSetting.css.ts
+++ b/src/shared/components/modalContentRegionSetting/modalContentRegionSetting.css.ts
@@ -1,0 +1,19 @@
+import { style } from '@vanilla-extract/css';
+import { globalTheme } from '@/shared/styles/globalTheme.css';
+
+export const DivStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: '2.4rem',
+  marginTop: '17.2rem',
+});
+
+export const DivParagraphStyle = style({
+  ...globalTheme.fonts.bodyReg16,
+  color: globalTheme.colors.gray_19,
+  display: 'flex',
+  alignItems: 'center',
+  gap: '1.2rem',
+});

--- a/src/shared/components/modalContentRegionSetting/modalContentRegionSetting.tsx
+++ b/src/shared/components/modalContentRegionSetting/modalContentRegionSetting.tsx
@@ -1,0 +1,22 @@
+import Button from '@/shared/components/button/button';
+import Input from '@/shared/components/input/input';
+import { DivParagraphStyle, DivStyle } from './modalContentRegionSetting.css';
+
+const ModalContentRegionSetting = () => {
+  return (
+    <div className={DivStyle}>
+      <Input placeholder="지역 선택" />
+
+      <p className={DivParagraphStyle}>
+        본인이 거주 및 출생한 지역을 자유롭게 선택할 수 있습니다. 지역정보는
+        서비스 내 지역 경쟁
+        <br />
+        콘텐츠에 사용됩니다.
+      </p>
+
+      <Button>완료</Button>
+    </div>
+  );
+};
+
+export default ModalContentRegionSetting;

--- a/src/shared/components/modalContentSchoolSetting/modalContentSchoolSetting.css.ts
+++ b/src/shared/components/modalContentSchoolSetting/modalContentSchoolSetting.css.ts
@@ -1,0 +1,28 @@
+import { style } from '@vanilla-extract/css';
+import { globalTheme } from '@/shared/styles/globalTheme.css';
+
+export const DivStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: '3.2rem',
+  marginTop: '4.8rem',
+});
+
+export const DivInputStyle = style({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+  gap: '2.4rem',
+  marginTop: '1.2rem',
+});
+
+export const checkboxButtonStyle = style({
+  ...globalTheme.fonts.bodyReg16,
+  color: globalTheme.colors.gray_19,
+  display: 'flex',
+  alignItems: 'center',
+  gap: '1.2rem',
+});

--- a/src/shared/components/modalContentSchoolSetting/modalContentSchoolSetting.tsx
+++ b/src/shared/components/modalContentSchoolSetting/modalContentSchoolSetting.tsx
@@ -1,0 +1,29 @@
+import Button from '@/shared/components/button/button';
+import Input from '@/shared/components/input/input';
+import Checkbox from '@/shared/assets/svg/check_btn.svg';
+import {
+  DivStyle,
+  DivInputStyle,
+  checkboxButtonStyle,
+} from './modalContentSchoolSetting.css';
+
+export function ModalContentSchoolSetting() {
+  return (
+    <div className={DivStyle}>
+      <div className={DivInputStyle}>
+        <Input variant="search" placeholder="대학교 검색" />
+        <Input placeholder="대학 이메일 확인" />
+        <button className={checkboxButtonStyle}>
+          <Checkbox />
+          서비스 제공을 목적으로 개인정보 수집 및 이용(필수)에 동의 합니다.
+        </button>
+        <Button>인증번호 전송</Button>
+      </div>
+
+      <div className={DivInputStyle}>
+        <Input placeholder="인증번호 입력" />
+        <Button>다음</Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #14

## ✅ 작업 리스트

- [x] web기준 Modal 창 구현
- [x] 정보변경 view 구현
- [x] 로그아웃 탈퇴 기능없이 view만 구현

## 🔧 작업 내용
```
Parallel Routes, Intercepting Routes을 사용하여 Modal을 구현 하였습니다.
해당 방식을 사용하면 soft(코드 내에서 접근)만 가능하고, 주소창을 통한 강제적 접근은 차단 됩니다.
```

- 위의 접근 방식을 사용하면 url로 접근했을 때 경로는 차단되지만 새로고침했을 떄 404 뜨는 이슈가 있어서, 해당 모달이 쓰이는 /user에 모달 url을`(user/[userId]/main-setting` 설정하고, 해당 경로를 intercept하는 방식으로 변경하였습니다. 

- url을 통한 모달 접근은 문제 없는 방식이라고 생각하지만, 다른 사용자의 모달을 접근하는 경우를 막는 방법을 추후 고안해봐야할것 같습니다.



<Link href="/user/[userId]/main-setting">Open modal</Link> 을 통해 간단하게 모달을 표시할 수 있습니다.

!!텍스트 버튼 (호버 프레스) 없어서 일단 스타일 적용안된 버튼 넣어둠

##🤬충돌시 확인할 코드!🤬
- 모두 해결

## 🧐 새로 알게된 점
Parallel Routes : 두개이상의 page를(페이지, 모달) 동시에 렌더링 할 수 있게 하는 next.js의 기술
next.js 에서만 사용하는 코드와 기술들이 있는 것을 알게됨

## 🤔 궁금한 점

## 📸 스크린샷 / GIF / Link

모달창
![image](https://github.com/user-attachments/assets/f14d9921-203c-4458-838c-730999855300)

소속 학교 변경
![image](https://github.com/user-attachments/assets/fbdb74bf-0be3-426b-b6ca-09c6974409d1)

소속 지역 변경
![image](https://github.com/user-attachments/assets/06b053a1-e46d-4d87-bce8-7277d3ee9209)

