### PR TITLE
[ Fix ] 버셀 402 오류로 인한 이미지 최적화 기능을 해제합니다.

### DIFF
--- a/apps/mobile/next.config.mjs
+++ b/apps/mobile/next.config.mjs
@@ -16,6 +16,7 @@ const nextConfig = {
     dangerouslyAllowSVG: true, // svg 이미지 허용
     contentDispositionType: 'attachment',
     contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: 'https',

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -16,6 +16,7 @@ const nextConfig = {
     dangerouslyAllowSVG: true, // svg 이미지 허용
     contentDispositionType: 'attachment',
     contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: 'https',


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

## 🔥 Related Issues

- close #51 
## ✅ 작업 리스트

- [x] 이미지 최적화 기능 해제


## 🔧 작업 내용

next의 config 파일에서 image 최적화 기능을 해제했어요.
unoptimized 설정을 true로 해주면 되요!

## 🧐 새로 알게된 점

## 🤔 궁금한 점

## 📸 스크린샷 / GIF / Link
